### PR TITLE
added user binary build path to $PATH

### DIFF
--- a/tor.sh
+++ b/tor.sh
@@ -67,12 +67,14 @@ sleep 1
 sudo wget https://storage.googleapis.com/golang/go1.9.linux-armv6l.tar.gz
 sudo tar -C /usr/local -xzf go1.9.linux-armv6l.tar.gz
 sudo rm go1.9.linux-armv6l.tar.gz
+sudo mkdir -p /home/bulwark/go/bin
 sleep 1
 # put into global /etc/profile
 export PATH=$PATH:/usr/local/go/bin
 sleep 1
 # put into user's ~/.profile
 export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
 source /etc/profile
 source ~/.profile
 sleep 1


### PR DESCRIPTION
when the bwk-dash binary is built it places the binary in the $GOPATH/bin folder for inclusion into the $PATH variable which should be set during installation of Go.  I